### PR TITLE
Fixed typo in README.md in the CDN <script> src

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ or clone this repository and copy `qart.min.js` to your project.
 
 ### CDN
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/qartjs/1.0.2/qart.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qartjs/1.0.2/qart.min.js"></script>
 ```
 
 ## Usage


### PR DESCRIPTION
Went from `<script src="//cdnjs.cloudflare.com/ajax/libs/qartjs/1.0.2/qart.min.js"></script>` to `<script src="https://cdnjs.cloudflare.com/ajax/libs/qartjs/1.0.2/qart.min.js"></script>`.

Originally, if you copy-pasted, the import would not work.